### PR TITLE
render the command name in description as a link

### DIFF
--- a/lib/Open/This.pm
+++ b/lib/Open/This.pm
@@ -190,7 +190,7 @@ sub _maybe_find_local_file {
 
 =head1 DESCRIPTION
 
-This module powers the C<ot> command line script, which tries to do the right
+This module powers the L<ot> command line script, which tries to do the right
 thing when opening a file.  Imagine your C<$ENV{EDITOR}> is set to C<vim>.
 (This should also work for C<emacs> and C<nano>.)  The following examples
 demonstrate how your input is translated when launching your editor.


### PR DESCRIPTION
Hi oalders,
I find that an L-tag for the command is much better, because then it is rendered as a clickable link to the commands POD in metacpan.
What do you think?