### PR TITLE
don't exec if $EDITOR is empty, die with message

### DIFF
--- a/script/ot
+++ b/script/ot
@@ -40,7 +40,8 @@ if ($browse) {
 
 my @editor_args = editor_args_from_parsed_text($parsed);
 
-$ENV{EDITOR} ? exec $ENV{EDITOR}, @editor_args : die('nothing in EDITOR');
+$ENV{EDITOR} ? exec $ENV{EDITOR}, @editor_args
+             : die('Please ensure your $EDITOR env var has been set');
 
 # ABSTRACT: parse text and (hopefully) open an editor with the correct arguments
 # PODNAME: ot

--- a/script/ot
+++ b/script/ot
@@ -40,7 +40,7 @@ if ($browse) {
 
 my @editor_args = editor_args_from_parsed_text($parsed);
 
-exec $ENV{EDITOR}, @editor_args;
+$ENV{EDITOR} ? exec $ENV{EDITOR}, @editor_args : die('nothing in EDITOR');
 
 # ABSTRACT: parse text and (hopefully) open an editor with the correct arguments
 # PODNAME: ot


### PR DESCRIPTION
EDITOR seems not to be set by default on my xubuntu.
So I always run into this error:

```
user@host:~/repos/open-this[master]$ ot Open::This
Use of uninitialized value in exec at /home/user/perl5/perlbrew/perls/perl-5.22.4/bin/ot line 43.
Can't exec "": Datei oder Verzeichnis nicht gefunden at /home/user/perl5/perlbrew/perls/perl-5.22.4/bin/ot line 43.
```
This error can the be fixed like so:
`user@host:~/repos/open-this[master]$ EDITOR=vim ot Open::This`
(or in `.bashrc` for sure)

With this patch it would die like this, which is a bit more kind:
```
user@host:~/repos/open-this[master]$ EDITOR='' perl script/ot Open::This
nothing in EDITOR at script/ot line 43.
```

I thought about making this check at the start of the script. But I thought, maybe `-b` should run, even if EDITOR is empty...