### PR TITLE
Print usage when ot is called with no arguments

### DIFF
--- a/script/ot
+++ b/script/ot
@@ -9,6 +9,9 @@ use Open::This qw(
     parse_text
 );
 use Path::Tiny qw( path );
+use Pod::Usage;
+
+pod2usage("Error: missing argument\n") unless @ARGV;
 
 my $browse;
 if ( $ARGV[0] eq '-b' ) {


### PR DESCRIPTION
Currently, calling `ot` with no arguments results in a rather unhelpful message:

```
$ ot
Use of uninitialized value $ARGV[0] in string eq at .../bin/ot line 14.
Could not locate file
```

This patch makes it so that calling it with no arguments prints an error message and the usage, derived from the embedded documentation:

```
$ ot
Error: missing argument

Usage:
        ot "lib/Foo/Bar.pm line 222"
        # Executes $ENV{EDITOR} +222 lib/Foo/Bar.pm

        ot "./lib/Foo/Bar.pm:135:20: blah;"

... etc ...
```

It uses Pod::Usage to do this, which should be in core.