### PR TITLE
Add support for Kate editor

### DIFF
--- a/t/kate.t
+++ b/t/kate.t
@@ -1,0 +1,42 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Open::This qw( to_editor_args );
+use Test::Differences qw( eq_or_diff );
+use Test::More;
+
+local $ENV{EDITOR} = 'kate';
+
+eq_or_diff(
+    [ to_editor_args('t/git.t') ],
+    [
+        't/git.t',
+    ],
+    'filename'
+);
+
+eq_or_diff(
+    [ to_editor_args('t/git.t:10') ],
+    [
+        '--line',
+        '10',
+        't/git.t',
+    ],
+    'line'
+);
+
+eq_or_diff(
+    [ to_editor_args('t/git.t:10:22') ],
+    [
+        '--line',
+        '10',
+        '--column',
+        '22',
+        't/git.t',
+    ],
+    'line and column'
+);
+
+done_testing();


### PR DESCRIPTION
This patch adds support for Kate, the default text editor in KDE.

This is a bit different to the existing editors, since unlike the rest, this is a graphical editor (not one that runs in the terminal). Still, when a window is already open, running `kate filename` will open that file in the existing window, so a utility like `ot` can be very useful (it certainly has been for me).

The one thing that could be improved is that, if no window is open, `ot` will create a new one, but will not detach from it, which can be a bit annoying (sadly, Kate does not seem to have an option to avoid this, so it needs to be done with invocations like `kate foo &`, which I'm not sure if we can use in this case).

Anyway, let me know what you think!