### PR TITLE
Support the pseudo-paths that git diff and friends will display

### DIFF
--- a/lib/Open/This.pm
+++ b/lib/Open/This.pm
@@ -36,12 +36,17 @@ sub parse_text {
     $parsed{sub_name}      = _maybe_extract_subroutine_name( \$text );
 
     # Is this an actual file.
-    $parsed{file_name} = $text if -e path($text);
-    if ( !exists $parsed{file_name} ) {
-        if ( my $bin = _which($text) ) {
-            $parsed{file_name} = $bin;
-            $text = $bin;
+    if ( -e path( $text ) ) {
+        $parsed{file_name} = $text;
+        if ( !exists $parsed{file_name} ) {
+            if ( my $bin = _which($text) ) {
+                $parsed{file_name} = $bin;
+                $text = $bin;
+            }
         }
+    }
+    else {
+        $parsed{file_name} = _maybe_git_diff_path( $text );
     }
 
     $parsed{is_module_name} = is_module_name($text);
@@ -267,6 +272,18 @@ sub _maybe_find_local_file {
             return "$path";
         }
     }
+    return undef;
+}
+
+sub _maybe_git_diff_path {
+    my $file_name = shift;
+
+    if ( $file_name =~ m|^[ab]/(.+)$| ) {
+        if ( -e path( $1 ) ) {
+            return $1;
+        }
+    }
+
     return undef;
 }
 

--- a/t/Open/This.t
+++ b/t/Open/This.t
@@ -225,6 +225,24 @@ eq_or_diff(
 );
 
 {
+    my $text = 'a/t/test-data/file';
+    eq_or_diff(
+        parse_text($text),
+        {
+            file_name     => 't/test-data/file',
+            original_text => $text,
+        },
+        'a git-diff path and the file exists'
+    );
+}
+
+eq_or_diff(
+    parse_text('a/t/test-data/i-m-not-here'),
+    undef,
+    'could have been a git diff file name, but it doesn\'t exist'
+);
+
+{
     my $text = 't/test-data/file with spaces';
     eq_or_diff(
         parse_text($text),


### PR DESCRIPTION
Your looking at a commit in your git log and git/diff show two paths like
a/foo/bar and b/foo/bar. Simply copying one of those file names is difficult,
because simply double-clicking will include "a/" oder "b/".  So Open::This can
take a look at the path, see whether it starts with "a/" or "b/" and remove the
prefix if the rest of the path makes any sense.