### PR TITLE
Support the pseudo-paths that git diff and friends will display

### DIFF
--- a/lib/Open/This.pm
+++ b/lib/Open/This.pm
@@ -36,7 +36,13 @@ sub parse_text {
     $parsed{sub_name}      = _maybe_extract_subroutine_name( \$text );
 
     # Is this an actual file.
-    $parsed{file_name} = $text if -e path($text);
+    if ( -e path( $text ) ) {
+        $parsed{file_name} = $text;
+    }
+    elsif ( my $file_name = _maybe_git_diff_path( $text )) {
+        $parsed{file_name} = $file_name;
+    }
+
     if ( !exists $parsed{file_name} ) {
         if ( my $bin = _which($text) ) {
             $parsed{file_name} = $bin;
@@ -267,6 +273,18 @@ sub _maybe_find_local_file {
             return "$path";
         }
     }
+    return undef;
+}
+
+sub _maybe_git_diff_path {
+    my $file_name = shift;
+
+    if ( $file_name =~ m|^[ab]/(.+)$| ) {
+        if ( -e path( $1 ) ) {
+            return $1;
+        }
+    }
+
     return undef;
 }
 

--- a/script/ot
+++ b/script/ot
@@ -108,6 +108,12 @@ disks.  All security caveats apply when requiring 3rd party modules.
     # of this repository on a local checkout.
     ot https://github.com/oalders/git-helpers/blob/master/lib/Git/Helpers.pm#L50
 
+    # open a file that was mentioned in the output of diff or
+    # git diff or git log -p, etc:
+    ot a/foo/bar
+    # will open foo/bar if it exists
+
+
 =head1 ENVIRONMENT VARIABLES
 
 By default, C<ot> will search your C<lib> and C<t/lib> directories for local files.  You can override this via the C<$ENV{OPEN_THIS_LIBS}> variable.  It accepts a comma-separated list of libs.

--- a/t/Open/This.t
+++ b/t/Open/This.t
@@ -242,6 +242,12 @@ eq_or_diff(
     'could have been a git diff file name, but it doesn\'t exist'
 );
 
+eq_or_diff(
+    parse_text('b/t/test-data/i-m-not-here'),
+    undef,
+    'could have been the other variant of a git diff file name, but it doesn\'t exist'
+);
+
 {
     my $text = 't/test-data/file with spaces';
     eq_or_diff(

--- a/t/Open/This.t
+++ b/t/Open/This.t
@@ -225,6 +225,24 @@ eq_or_diff(
 );
 
 {
+    my $text = 'a/t/test-data/file';
+    eq_or_diff(
+        parse_text($text),
+        {
+            file_name     => 't/test-data/file',
+            original_text => $text,
+        },
+        'a git-diff path and the file exists'
+    );
+}
+
+eq_or_diff(
+    parse_text('a/t/test-data/i-m-not-here'),
+    undef,
+    'could have been a git diff file name, but it doesn\'t exist'
+);
+
+{
     my $text = 't/test-data/file with spaces';
     eq_or_diff(
         parse_text($text),


### PR DESCRIPTION
Your looking at a commit in your git log and git/diff show two paths like
a/foo/bar and b/foo/bar. Simply copying one of those file names is difficult,
because simply double-clicking will include "a/" oder "b/".  So Open::This can
take a look at the path, see whether it starts with "a/" or "b/" and remove the
prefix if the rest of the path makes any sense.