### PR TITLE
Use Module::Util to find modules without requiring them

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,6 +10,7 @@ Git::GatherDir.exclude_filename = Dockerfile
 
 [Prereqs / RuntimeRequires]
 Git::Helpers = 0.000016
+Module::Util = 0.016
 
 [StaticInstall]
 mode = on

--- a/lib/Open/This.pm
+++ b/lib/Open/This.pm
@@ -12,6 +12,8 @@ our @EXPORT_OK = qw(
     to_editor_args
 );
 
+use Module::Util;
+
 use Module::Runtime qw(
     is_module_name
     module_notional_filename
@@ -68,7 +70,7 @@ sub parse_text {
     # This is a loadable module.  Have this come after the local module checks
     # so that we don't default to installed modules.
     if ( !$parsed{file_name} && $parsed{is_module_name} ) {
-        my $found = _module_to_filename($text);
+        my $found = Module::Util::find_installed($text);
         if ($found) {
             $parsed{file_name} = $found;
         }
@@ -110,16 +112,6 @@ sub maybe_get_url_from_parsed_text {
 
     $parsed->{remote_file_url} = $clone;
     return $clone;
-}
-
-sub _module_to_filename {
-    my $name = shift;
-    return undef unless ( defined $name && is_module_name($name) );
-    try { require_module($name) };
-
-    my $notional = module_notional_filename($name);
-
-    return exists $INC{$notional} ? $INC{$notional} : undef;
 }
 
 sub to_editor_args {


### PR DESCRIPTION
This makes it possible to use ot to open modules that do require-time magic, like [Acme::Bleach](https://metacpan.org/pod/Acme::Bleach).

Fixes #8 