### PR TITLE
Make sure we don't require modules to find them

### DIFF
--- a/t/lib/Foo/Require.pm
+++ b/t/lib/Foo/Require.pm
@@ -1,0 +1,7 @@
+package Foo::Require;
+
+# See https://github.com/oalders/open-this/issues/8
+# and https://github.com/oalders/open-this/issues/24
+warn 'This package warns on require';
+
+1;

--- a/t/require.t
+++ b/t/require.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+
+use Open::This qw( parse_text );
+use Test::More;
+use Test::Warnings;
+
+# Simulate an installed, non-local module
+local $ENV{OPEN_THIS_LIBS} = '';
+use lib 't/lib';
+
+parse_text('Foo::Require');
+
+done_testing();


### PR DESCRIPTION
This is an attempt at taking care of #25.

Not 100% convinced this is the best way to implement it, but I did make sure it failed with fb8213f7770, which was before the fix from #24.

Let me know if I missed anything!