### PR TITLE
Avoid false positives when testing URLs

### DIFF
--- a/lib/Open/This.pm
+++ b/lib/Open/This.pm
@@ -56,7 +56,7 @@ sub parse_text {
 
     $parsed{is_module_name} = is_module_name($text);
 
-    if ( !$parsed{file_name} && $text =~ m{\Ahttp}i ) {
+    if ( !$parsed{file_name} && $text =~ m{\Ahttps?://}i ) {
         $parsed{file_name} = _maybe_extract_file_from_url( \$text );
     }
 

--- a/t/github.t
+++ b/t/github.t
@@ -39,4 +39,10 @@ eq_or_diff(
     'full https GitHub URL with invalid fragment'
 );
 
+eq_or_diff(
+    [ to_editor_args('HTTP::FakeTestClass') ],
+    ['t/lib/HTTP/FakeTestClass.pm'],
+    'non-URL package name starting with HTTP gets handled properly'
+);
+
 done_testing();

--- a/t/lib/HTTP/FakeTestClass.pm
+++ b/t/lib/HTTP/FakeTestClass.pm
@@ -1,0 +1,3 @@
+package HTTP::FakeTestClass;
+
+1;


### PR DESCRIPTION
The existing check was for `/\Ahttp/i`, which would match with eg. package names that started with "HTTP" (like HTTP::Tiny, etc). This would issue a warning.

By making this test for `m{\Ahttps?://}` we can avoid incorrectly thinking these are URLs.