### PR TITLE
strip trailing colons before parsing text

### DIFF
--- a/lib/Open/This.pm
+++ b/lib/Open/This.pm
@@ -30,6 +30,11 @@ sub parse_text {
         $text =~ s/^\s+|\s+$//g;
     }
 
+    # Don't fail on a trailing colon which was accidentally pasted.
+    if ($text) {
+        $text =~ s{:\z}{};
+    }
+
     return undef if !$text;
     my %parsed = ( original_text => $text );
 

--- a/t/ansible.t
+++ b/t/ansible.t
@@ -63,7 +63,7 @@ for my $original_text (@snippets) {
         parse_text($text),
         {
             file_name     => $path->stringify,
-            original_text => $chomped,
+            original_text => qq{'$path'},
         },
         'parse_text without line'
     );

--- a/t/open-this.t
+++ b/t/open-this.t
@@ -203,6 +203,19 @@ local $ENV{EDITOR} = 'vim';
     );
 }
 
+{
+    my $text = 't/lib/Foo/Bar.pm:32:';
+    eq_or_diff(
+        parse_text($text),
+        {
+            file_name     => 't/lib/Foo/Bar.pm',
+            line_number   => 32,
+            original_text => 't/lib/Foo/Bar.pm:32',
+        },
+        'trailing colon is stripped'
+    );
+}
+
 eq_or_diff(
     parse_text('t/Does/Not/Exist'),
     undef,


### PR DESCRIPTION
The trailing colon will not be preserved in the saved original text,
since it's going to be regarded as meaningless.
