### PR TITLE
Make Git::Helpers optional

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,13 +12,18 @@ StaticInstall.mode = on
 StaticInstall.dry_run = 0
 
 [Prereqs / RuntimeRequires]
-Git::Helpers = 0.000016
 Module::Util = 0.016
 perl = 5.12.0
+
+[Prereqs / RuntimeRecommends]
+Git::Helpers = 0.000016
 
 [Prereqs / TestRequires]
 Test::Simple = 1.302177
 Test::Script = 1.29
+
+[Prereqs / TestRecommends]
+Git::Helpers = 0.000016
 
 [GitHubREADME::Badge]
 badges = github_actions/test

--- a/lib/Open/This.pm
+++ b/lib/Open/This.pm
@@ -19,6 +19,7 @@ use Module::Runtime qw(
 );
 use Module::Util ();
 use Path::Tiny qw( path );
+use Try::Tiny qw( catch try );
 use URI ();
 
 ## no critic (Subroutines::ProhibitExplicitReturnUndef)
@@ -93,7 +94,18 @@ sub parse_text {
 }
 
 sub maybe_get_url_from_parsed_text {
-    require Git::Helpers;
+    my $err;
+    try {
+        require_module('Git::Helpers');
+    }
+    catch {
+        $err = $_;
+    };
+
+    if ($err) {
+        warn 'This feature requires Git::Helpers to be installed';
+        return;
+    }
 
     my $parsed = shift;
     return undef unless $parsed && $parsed->{file_name};

--- a/t/git.t
+++ b/t/git.t
@@ -2,16 +2,17 @@ use strict;
 use warnings;
 
 use Carp::Always;
-use Git::Helpers qw( is_inside_work_tree );
 use Open::This qw( maybe_get_url_from_parsed_text );
 use Test::More import => [qw( done_testing is ok skip )];
+use Test::Needs qw( Git::Helpers );
 use Test::Requires::Git;
 use URI ();
 
 test_requires_git();
 
 SKIP: {
-    skip 'must be inside Git checkout', 1 unless is_inside_work_tree();
+    skip 'must be inside Git checkout', 1
+        unless Git::Helpers::is_inside_work_tree();
     is( maybe_get_url_from_parsed_text(),     undef, 'undef on undef' );
     is( maybe_get_url_from_parsed_text( {} ), undef, 'undef on empty hash' );
 


### PR DESCRIPTION
It's not bringing that much to the table, so moving this to recommends
should reduce the deps by a fair number.

Closes #45 