### PR TITLE
Search recursively for .go files

### DIFF
--- a/lib/Open/This.pm
+++ b/lib/Open/This.pm
@@ -53,6 +53,18 @@ sub parse_text {
     elsif ( my $file_name = _maybe_git_diff_path($text) ) {
         $parsed{file_name} = $file_name;
     }
+    elsif ( $text =~ m{^[^/]+\.go$} ) {
+        my $threshold_init = 5000;
+        my $iter = path('.')->iterator({ recurse => 1 });
+        my $threshold = $threshold_init;
+        while ( $threshold-- > 0 ) {
+            my $path = $iter->();
+            ( $threshold, $parsed{file_name} ) = ( 0, "$path" )
+                if $path->basename eq $text;
+        }
+        warn "Only $threshold_init files searched recursively"
+            unless exists $parsed{file_name};
+    }
 
     if ( !exists $parsed{file_name} ) {
         if ( my $bin = _which($text) ) {

--- a/t/open-this.t
+++ b/t/open-this.t
@@ -309,6 +309,19 @@ eq_or_diff(
     );
 }
 
+{
+    my $text = 'test.go:4';
+    eq_or_diff(
+        parse_text($text),
+        {
+            file_name     => 't/test-data/foo/bar/test.go',
+            line_number   => 4,
+            original_text => $text,
+        },
+        'find a go file'
+    );
+}
+
 eq_or_diff(
     [ to_editor_args('t/test-data/file with spaces') ],
     ['t/test-data/file with spaces'],

--- a/t/test-data/foo/bar/test.go
+++ b/t/test-data/foo/bar/test.go
@@ -1,0 +1,5 @@
+package test
+
+import (
+       "testing"
+)


### PR DESCRIPTION
Go test failures don't always report paths to test files. If the file doesn't exist in the current directory, search for it in the subdirs.

Fixes #30.